### PR TITLE
Fix some typo and Change ^M to \n in some file

### DIFF
--- a/contents/architecture.tex
+++ b/contents/architecture.tex
@@ -131,7 +131,7 @@
 \begin{figure}[!htbp]
 \centering
 \includegraphics[width=0.9\textwidth]{figures/tf-graph-construction.png}
-\caption{图构造}}
+\caption{图构造}
  \label{fig:tf-graph-construction}
 \end{figure}
 
@@ -144,7 +144,7 @@
 \begin{figure}[!htbp]
 \centering
 \includegraphics[width=0.9\textwidth]{figures/tf-graph-execution.png}
-\caption{图执行}}
+\caption{图执行}
  \label{fig:tf-graph-execution}
 \end{figure}
 
@@ -155,7 +155,7 @@
 \begin{figure}[!htbp]
 \centering
 \includegraphics[width=1.0\textwidth]{figures/tf-graph-split-by-task.png}
-\caption{图分裂：按任务划分}}
+\caption{图分裂：按任务划分}
  \label{fig:tf-graph-split-by-task}
 \end{figure}
 
@@ -170,7 +170,7 @@
 \begin{figure}[!htbp]
 \centering
 \includegraphics[width=1.0\textwidth]{figures/tf-register-graph.png}
-\caption{子图注册：插入Send和Recv节点}}
+\caption{子图注册：插入Send和Recv节点}
  \label{fig:tf-register-graph}
 \end{figure}
 
@@ -181,7 +181,7 @@
 \begin{figure}[!htbp]
 \centering
 \includegraphics[width=1.0\textwidth]{figures/tf-run-graph.png}
-\caption{子图执行}}
+\caption{子图执行}
  \label{fig:tf-run-graph}
 \end{figure}
 
@@ -202,7 +202,7 @@
 \begin{figure}[!h]
 \centering
 \includegraphics[width=0.7\textwidth]{figures/tf-create-session-overview.png}
-\caption{创建会话}}
+\caption{创建会话}
  \label{fig:tf-create-session-overview}
 \end{figure}
 
@@ -213,7 +213,7 @@
 \begin{figure}[!h]
 \centering
 \includegraphics[width=1.0\textwidth]{figures/tf-run-step-overview.png}
-\caption{迭代执行}}
+\caption{迭代执行}
  \label{fig:tf-run-step-overview}
 \end{figure}
 
@@ -251,7 +251,7 @@ def run_partitions(rendezvous, executors_and_partitions, inputs, outputs):
 \begin{figure}[!h]
 \centering
 \includegraphics[width=0.7\textwidth]{figures/tf-recv-tensor-overview.png}
-\caption{Worker之间的数据交换}}
+\caption{Worker之间的数据交换}
  \label{fig:tf-recv-tensor-overview}
 \end{figure}
 
@@ -262,7 +262,7 @@ def run_partitions(rendezvous, executors_and_partitions, inputs, outputs):
 \begin{figure}[!h]
 \centering
 \includegraphics[width=0.7\textwidth]{figures/tf-close-session-overview.png}
-\caption{关闭会话}}
+\caption{关闭会话}
  \label{fig:tf-close-session-overview}
 \end{figure}
 

--- a/contents/code-reading.tex
+++ b/contents/code-reading.tex
@@ -228,7 +228,7 @@ spec: r3 || r2 || r1 || rd
 
  \item \ascii{Stage 1}的划分
    \begin{enum}
-     \eitem{\ascii{A}没有父亲}RDD}，\ascii{Stage(1)}划分结束。特殊地\ascii{Stage(1)}仅包含\ascii{RDD A}。}
+	   \eitem{\ascii{A}没有父亲\ascii{RDD}，\ascii{Stage(1)}划分结束。特殊地\ascii{Stage(1)}仅包含\ascii{RDD A}。}
    \end{enum}
  \item \ascii{Stage 2}的划分
    \begin{enum}

--- a/contents/ice-breaker.tex
+++ b/contents/ice-breaker.tex
@@ -51,8 +51,6 @@
 
 \subsection{图示说明}
 
-\begin{content}
-
 为了更好地可视化整个训练过程，使用\ascii{matplotlib}工具包绘制了\ascii{5}种类型的画板。如\refig{mnist-training-digits}所示，表示一个\ascii{mini-batch}的训练样本数据集。其中，\code{batch\_size = 100}，白色背景表示数字被正确识别；而红色背景表示数字被误分类，手写数字的左侧标识了正确的标签值，而右侧标识了错误的预测值。
 
 \ascii{MNIST}拥有\ascii{50000}个训练样本，如果\code{batch\_size}为\ascii{100}，则需要迭代\ascii{500}次才能完整地遍历一次训练样本数据集，常称为一个\ascii{epoch}周期。
@@ -414,21 +412,21 @@ with tf.Session() as sess:
 为了形式化地描述多层感知器模型，此处定义了一些常用符号。
 
 \begin{itemize}
-   \item \alert{$ {n_{\ell}} $}: 网络层数，其中第$0$层为输入层，第$n_{\ell}$层为输出层
-   \item \alert{$ {s_{\ell}} $}: 第$\ell$层的节点数，$ \ell = 0, 1, ..., n_{\ell} $
-   \item \alert{$ w_{ji}^{(\ell)} $}: 第$(\ell-1)$层节点$i$与第$\ell$层节点$j$之间的权重，$ \ell = 1, ..., n_{\ell} $
-   \item \alert{$ b_i^{(\ell)} $}: 第$\ell$层节点$i$的偏置项，$ \ell = 1, ..., n_{\ell} $
-   \item \alert{$ a_i^{(\ell)} $}: 第$\ell$层节点$i$的输出，$ \ell = 1, ..., n_{\ell}, x = a^{(0)}, y = a^{(n_{\ell})} $
-   \item \alert{$ z_i^{(\ell)} $}: 第$\ell$层节点$i$的权重和，$ \ell = 1, ..., n_{\ell} $
-   \item \alert{$ \delta _i^{(\ell)} $}: 第$\ell$层节点$i$的误差项，$ \ell = 1, ..., n_{\ell} $
-   \item \alert{$ S = \{ ({x^{(t)}},{y^{(t)}});t = 1,2,...,m\} $}: 样本空间
+   \item $ {n_{\ell}} $: 网络层数，其中第$0$层为输入层，第$n_{\ell}$层为输出层
+   \item $ {s_{\ell}} $: 第$\ell$层的节点数，$ \ell = 0, 1, ..., n_{\ell} $
+   \item $ w_{ji}^{(\ell)} $: 第$(\ell-1)$层节点$i$与第$\ell$层节点$j$之间的权重，$ \ell = 1, ..., n_{\ell} $
+   \item $ b_i^{(\ell)} $: 第$\ell$层节点$i$的偏置项，$ \ell = 1, ..., n_{\ell} $
+   \item $ a_i^{(\ell)} $: 第$\ell$层节点$i$的输出，$ \ell = 1, ..., n_{\ell}, x = a^{(0)}, y = a^{(n_{\ell})} $
+   \item $ z_i^{(\ell)} $: 第$\ell$层节点$i$的权重和，$ \ell = 1, ..., n_{\ell} $
+   \item $ \delta _i^{(\ell)} $: 第$\ell$层节点$i$的误差项，$ \ell = 1, ..., n_{\ell} $
+   \item $ S = \{ ({x^{(t)}},{y^{(t)}});t = 1,2,...,m\} $: 样本空间
  \end{itemize}
 
 \subsubsection{前向传播}
 
 $z^{(\ell )}$表示$\ell$层的线性加权和，它由第$\ell - 1$层的输出$a^{(\ell  - 1)}$与第$\ell$层的权重矩阵$w^{(\ell )}$相乘，再加上第$\ell$层的偏置向量所得。
 
-推而广之，第$\ell$层的输出，由激活函数$f({z^{(\ell )}})$所得。其中，$a^{(0)}} = x, y = {a^{({n_\ell })}}$。
+推而广之，第$\ell$层的输出，由激活函数$f({z^{(\ell )}})$所得。其中，$a^{(0)} = x, y = {a^{({n_\ell })}}$。
 
 \[\begin{gathered}
   {z^{(\ell )}} = {w^{(\ell )}}{a^{(\ell  - 1)}} + {b^{(\ell )}} \hfill \\
@@ -804,7 +802,7 @@ with tf.Session() as sess:
 
 $Z^{(\ell )}$表示$\ell$层的线性加权和，它由第$\ell - 1$层的输出$A^{(\ell  - 1)}$与第$\ell$层的权重矩阵$W^{(\ell )}$卷积，再加上第$\ell$层的偏置向量所得。
 
-推而广之，第$\ell$层的输出，由激活函数$f({Z^{(\ell )}})$所得。其中，$A^{(0)}} = x, y = {A^{({n_\ell })}}$。
+推而广之，第$\ell$层的输出，由激活函数$f({Z^{(\ell )}})$所得。其中，$A^{(0)} = x, y = {A^{({n_\ell })}}$。
 
 \[\begin{gathered}
   {Z^{(\ell )}} = {A^{(\ell  - 1)}} * {W^{(\ell )}} + {b^{(\ell )}} \hfill \\

--- a/contents/input-pipeline.tex
+++ b/contents/input-pipeline.tex
@@ -387,3 +387,5 @@ private:
 同样的道理，下游\ascii{OP}从队列(文件名队列)中出队元素，一旦该队列元素为空，则自动抛出\code{OutOfRangeError}异常。该阶段对应的\code{QueueRunner}将感知该异常的发生，然后捕获异常并关闭下游的队列(样本队列)，退出线程的执行。
 
 在\ascii{Pipeline}的最后阶段，\code{train\_op}从样本队列中出队批次训练样本时，队列为空，并且队列被关闭了，则抛出\code{OutOfRangeError}异常，最终停止整个训练任务。
+
+\end{content}

--- a/contents/local.tex
+++ b/contents/local.tex
@@ -47,7 +47,11 @@
 
 也就是说，分裂和执行体现了\tf{}并发执行的设计理念。
 
+\end{content}
+
 \section{会话控制}
+
+\begin{content}
 
 在本地模式下，其运行时由\code{DirectSession}控制。一般地，\code{DirectSession}执行计算图时，各组件之间都是函数调用关系。但是，\code{DirectSession}也存在清晰的生命周期管理机制，如\refig{local-direct-session-lifecycle}所示。
 
@@ -418,9 +422,12 @@ void FIFOQueue::TryEnqueue(const Tuple& tuple, OpKernelContext* ctx,
 \end{c++}
 \end{leftbar}
 
+\end{content}
 
 \section{剪枝}
 \label{sec:graph-operation-prune}
+
+\begin{content}
 
 \code{DirectSession::Run}执行时，首先完成\code{ClientGraph}的构造。事实上，\code{ClientGraph}的构造过程，主要完成\code{FullGraph}的剪枝算法，并生成\code{ClientGraph}。
 
@@ -850,6 +857,8 @@ void PruneForTargets(Graph* g,
 }
 \end{c++}
 \end{leftbar}
+
+\end{content}
 
 \section{分裂}
 \label{sec:graph-operation-split}

--- a/contents/prog-env.tex
+++ b/contents/prog-env.tex
@@ -534,7 +534,7 @@ Hello, TensorFlow!
 
 创建一个\ascii{Eclipse C++}工程，如\refig{setup-eclipse}所示。确定唯一的项目名称，手动地指定\ascii{TensorFlow}源代码的根目录，并选择\ascii{Makefile}的空工程。然后，按照\ascii{Properties > C/C++ General > Paths and Symbols > Includes}配置头文件的搜索目录。
 
-\begin{table}[!htbl]
+\begin{table}[!htbp]
 \resizebox{0.95\textwidth}{!} {
 \begin{tabular*}{1.2\textwidth}{@{}ll@{}}
 \toprule
@@ -549,10 +549,10 @@ Hello, TensorFlow!
 \label{tbl:tf-includes}
 \end{table}
 
-\begin{figure}[!htbl]
+\begin{figure}[!htbp]
 \centering
 \includegraphics[width=0.75\textwidth]{figures/setup-eclipse.png}
-\caption{创建Eclipse C++工程}}
+\caption{创建Eclipse C++工程}
  \label{fig:setup-eclipse}
 \end{figure}
 
@@ -560,7 +560,7 @@ Hello, TensorFlow!
 
 不幸的是，\ascii{Eigen}对外公开的头文件缺少\code{.h}的后缀名，\ascii{CDT}无法解析相关的符号。请参阅\code{\href{http://eigen.tuxfamily.org/index.php?title=IDEs}{http://eigen.tuxfamily.org/index.php?title=IDEs}}相关说明，按照\ascii{Preferences > C/C++ > Coding Style > Organize Includes > Header Substitution}导入\code{eigen-header-substitution.xml}文件，如\refig{eclipse-eigen3}所示。
 
-\begin{figure}[!htbl]
+\begin{figure}[!htbp]
 \centering
 \includegraphics[width=0.75\textwidth]{figures/eclipse-eigen3.png}
 \caption{替换\ascii{Eigen}的头文件}
@@ -586,7 +586,7 @@ Hello, TensorFlow!
 \begin{figure}[H]
 \centering
 \includegraphics[width=0.7\textwidth]{figures/tf-stack.png}
-\caption{TensorFlow技术栈}}
+\caption{TensorFlow技术栈}
  \label{fig:tf-stack}
 \end{figure}
 

--- a/contents/queue.tex
+++ b/contents/queue.tex
@@ -289,3 +289,5 @@ class QueueRunner(object):
 \subsection{关闭队列}
 
 当队列被关闭后，对于任何尝试\code{Enqueue}将会产生错误。但是，对于任何尝试\code{Dequeue}依然是成功的，只要队列中遗留元素；否则，\code{Dequeue}将立即失败，抛出\code{OutOfRangeError}异常，而不会阻塞等待更多元素被入队。
+
+\end{content}

--- a/contents/session.tex
+++ b/contents/session.tex
@@ -139,6 +139,7 @@ void TF_DeleteSession(TF_Session* s, TF_Status* status) {
 }
 \end{c++}
 \end{leftbar}
+\end{content}
 
 \section{默认会话}
 
@@ -366,4 +367,4 @@ class BaseSession(SessionInterface):
 \end{python}
 \end{leftbar}
 
-\begin{content}
+\end{content}

--- a/style/command.tex
+++ b/style/command.tex
@@ -1,1 +1,116 @@
-\newenvironment{enum}{  \begin{spacing}{1.2}  % \begin{enumerate}[1.]  \begin{enumerate}    \setlength{\itemsep}{0pt}     \setlength{\itemindent}{2em}    %\setlength{\listparindent}{2em}}{%  \end{enumerate}  \end{spacing}}\newenvironment{nitemize}{  \begin{itemize}    \setlength{\itemsep}{0pt}     \setlength{\itemindent}{2em}}{%  \end{itemize}}\newcommand{\suggest}[1]{\tikzstyle{mybox} = [draw=black, very thick,rectangle, rounded corners, inner sep=9pt, inner ysep=20pt]\tikzstyle{fancytitle} =[fill=white, text=black, ellipse]\noindent\begin{tikzpicture}\node [mybox] (box){%\begin{minipage}{\textwidth}\fangsong#1\end{minipage}};\node[fancytitle, right=10pt] at (box.north west) {\emph{建议}};% \node[fancytitle, rounded corners] at (box.east) {$\clubsuit$};\end{tikzpicture}}\newcommand{\notice}[1]{\tikzstyle{mybox} = [draw=black, very thick,rectangle, rounded corners, inner sep=9pt, inner ysep=20pt]\tikzstyle{fancytitle} =[fill=white, text=black]\noindent\begin{tikzpicture}\node [mybox] (box){%\begin{minipage}{\textwidth}\fangsong#1\end{minipage}};\node[fancytitle, right=10pt] at (box.north west) {\emph{注意}};%\node[fancytitle, rounded corners] at (box.east) {$\clubsuit$};\end{tikzpicture}}\newcommand{\tip}[1]{\tikzstyle{mybox} = [draw=black, very thick,rectangle, rounded corners, inner sep=9pt, inner ysep=20pt]\tikzstyle{fancytitle} =[fill=white, text=black]\noindent\begin{tikzpicture}\node [mybox] (box){%\begin{minipage}{\textwidth}\fangsong#1\end{minipage}};\node[fancytitle, right=10pt] at (box.north west) {\emph{提示}};%\node[fancytitle, rounded corners] at (box.east) {$\clubsuit$};\end{tikzpicture}}\newcommand\refch[1]{\ascii{第\ref{ch:#1}章(\nameref{ch:#1})}}\newcommand\refsec[1]{\ascii{\ref{sec:#1}节(\nameref{sec:#1})}}\newcommand\eitem[1]{\item {\itshape {#1}}}\newcommand\cpp{\ascii{C\nobreak+\nobreak+}}\newcommand\clang{\ascii{C}}\newcommand\tf{\ascii{TensorFlow}}\newcommand\quo[1]{“#1”}\newcommand\percent[1]{\ascii{#1\%}}\newcommand{\trans}{\emph{事务}}\newcommand{\act}{\emph{操作}}\newcommand{\seqact}{\emph{顺序操作}}\newcommand{\conact}{\emph{并发操作}}\newcommand{\atomact}{\emph{基本操作}}\newcommand{\syncact}{\emph{同步操作}}\newcommand{\asynact}{\emph{异步操作}}\newcommand{\action}[1]{\emph{\ascii{\itshape\_\_#1}}}\newcommand{\sigwait}{\action{sig\_wait}}\newcommand{\sigsync}{\action{sig\_sync}}\newcommand{\sigreply}{\action{sig\_reply}}\newcommand{\timerprot}{\action{timer\_prot}}\newcommand{\unknownevet}{\ascii{UNKNOWN\_EVENT}}\newcommand{\transdsl}{\ascii{Transaction DSL}}\newcommand{\oper}[1]{\ascii{Action#1}}\newcommand{\protproc}{\ascii{prot\_procedure}}%\newcommand{\code}[1]{\ascii{\small{\texttt{#1}}}}\newcommand{\code}[1]{\ascii{\footnotesize{\texttt{#1}}}}\newcommand{\script}[1]{\ascii{\scriptsize{\texttt{#1}}}}\newcommand{\inlinetitle}[1]{\large{\emph{#1}}}%\newcommand{\Email}{\begingroup \def\UrlLeft{<}\def\UrlRight{>} \urlstyle{tt}\Url}%\def\mailto|#1|{\href{mailto:#1}{Email|#1|}}\newcommand{\contrib}[2]{#1\quad{\small\quad\textit{#2}}\\[1ex]}\newcommand{\upcite}[1]{\textsuperscript{\cite{#1}}}
+\newenvironment{enum}
+{
+  \begin{spacing}{1.2}
+  % \begin{enumerate}[1.]
+  \begin{enumerate}
+    \setlength{\itemsep}{0pt} 
+    \setlength{\itemindent}{2em}
+    %\setlength{\listparindent}{2em}
+}{%
+  \end{enumerate}
+  \end{spacing}
+}
+
+\newenvironment{nitemize}
+{
+  \begin{itemize}
+    \setlength{\itemsep}{0pt} 
+    \setlength{\itemindent}{2em}
+}{%
+  \end{itemize}
+}
+
+
+\newcommand{\suggest}[1]{
+\tikzstyle{mybox} = [draw=black, very thick,
+rectangle, rounded corners, inner sep=9pt, inner ysep=20pt]
+\tikzstyle{fancytitle} =[fill=white, text=black, ellipse]
+\noindent
+\begin{tikzpicture}
+\node [mybox] (box){%
+\begin{minipage}{\textwidth}
+\fangsong
+#1
+\end{minipage}
+};
+\node[fancytitle, right=10pt] at (box.north west) {\emph{建议}};
+% \node[fancytitle, rounded corners] at (box.east) {$\clubsuit$};
+\end{tikzpicture}
+}
+
+\newcommand{\notice}[1]{
+\tikzstyle{mybox} = [draw=black, very thick,
+rectangle, rounded corners, inner sep=9pt, inner ysep=20pt]
+\tikzstyle{fancytitle} =[fill=white, text=black]
+\noindent
+\begin{tikzpicture}
+\node [mybox] (box){%
+\begin{minipage}{\textwidth}
+\fangsong
+#1
+\end{minipage}
+};
+\node[fancytitle, right=10pt] at (box.north west) {\emph{注意}};
+%\node[fancytitle, rounded corners] at (box.east) {$\clubsuit$};
+\end{tikzpicture}
+}
+
+\newcommand{\tip}[1]{
+\tikzstyle{mybox} = [draw=black, very thick,
+rectangle, rounded corners, inner sep=9pt, inner ysep=20pt]
+\tikzstyle{fancytitle} =[fill=white, text=black]
+\noindent
+\begin{tikzpicture}
+\node [mybox] (box){%
+\begin{minipage}{\textwidth}
+\fangsong
+#1
+\end{minipage}
+};
+\node[fancytitle, right=10pt] at (box.north west) {\emph{提示}};
+%\node[fancytitle, rounded corners] at (box.east) {$\clubsuit$};
+\end{tikzpicture}
+}
+
+\newcommand\refch[1]{\ascii{第\ref{ch:#1}章(\nameref{ch:#1})}}
+\newcommand\refsec[1]{\ascii{\ref{sec:#1}节(\nameref{sec:#1})}}
+
+\newcommand\eitem[1]{\item {\itshape {#1}}}
+\newcommand\cpp{\ascii{C\nobreak+\nobreak+}}
+\newcommand\clang{\ascii{C}}
+\newcommand\tf{\ascii{TensorFlow}}
+
+\newcommand\quo[1]{“#1”}
+
+\newcommand\percent[1]{\ascii{#1\%}}
+
+\newcommand{\trans}{\emph{事务}}
+\newcommand{\act}{\emph{操作}}
+\newcommand{\seqact}{\emph{顺序操作}}
+\newcommand{\conact}{\emph{并发操作}}
+\newcommand{\atomact}{\emph{基本操作}}
+\newcommand{\syncact}{\emph{同步操作}}
+\newcommand{\asynact}{\emph{异步操作}}
+\newcommand{\action}[1]{\emph{\ascii{\itshape\_\_#1}}}
+\newcommand{\sigwait}{\action{sig\_wait}}
+\newcommand{\sigsync}{\action{sig\_sync}}
+\newcommand{\sigreply}{\action{sig\_reply}}
+\newcommand{\timerprot}{\action{timer\_prot}}
+\newcommand{\unknownevet}{\ascii{UNKNOWN\_EVENT}}
+\newcommand{\transdsl}{\ascii{Transaction DSL}}
+\newcommand{\oper}[1]{\ascii{Action#1}}
+\newcommand{\protproc}{\ascii{prot\_procedure}}
+
+%\newcommand{\code}[1]{\ascii{\small{\texttt{#1}}}}
+\newcommand{\code}[1]{\ascii{\footnotesize{\texttt{#1}}}}
+\newcommand{\script}[1]{\ascii{\scriptsize{\texttt{#1}}}}
+
+
+\newcommand{\inlinetitle}[1]{\large{\emph{#1}}}
+
+%\newcommand{\Email}{\begingroup \def\UrlLeft{<}\def\UrlRight{>} \urlstyle{tt}\Url}
+%\def\mailto|#1|{\href{mailto:#1}{Email|#1|}}
+\newcommand{\contrib}[2]{#1\quad{\small\quad\textit{#2}}\\[1ex]}
+
+
+\newcommand{\upcite}[1]{\textsuperscript{\cite{#1}}}

--- a/style/page.tex
+++ b/style/page.tex
@@ -1,1 +1,65 @@
-%%%% fancyhdr设置页眉页脚%% 页眉页脚宏包\usepackage{fancyhdr}%% 页眉页脚风格\pagestyle{fancy}%%这两行代码是修改\leftmark和\rightmark的经典模式\renewcommand{\chaptermark}[1]{\markboth{{\hei {第\thechapter{}章}}\hspace 1  #1}{}}\renewcommand{\sectionmark}[1]{\markright{\thesection{} #1}}%% 清空当前页眉页脚的默认设置\fancyhf{}%\fancyhead[L]{\scriptsize \fangsong \ascii{ZTE}中兴}%\fancyhead[R]{\scriptsize \fangsong 内部公开}%\fancyhead[CE]{\scriptsize \fangsong \leftmark}%\fancyhead[CO]{\scriptsize \fangsong \rightmark}%\fancyfoot[RO, LE]{\scriptsize \thepage}%\fancyfoot[C]{\scriptsize \fangsong 本文中的所有信息均为中兴通讯股份有限公司内部信息，不得向外传播}\renewcommand{\headrulewidth}{0.4pt}\renewcommand{\footrulewidth}{0.4pt}%第{\couriernew\thechapter{}}章%%下面开始修改页眉和页脚\fancyhead[RE]{\fangsong \leftmark}\fancyhead[LO]{\fangsong \rightmark}\fancyhead[RO, LE]{\small \thepage}\fancypagestyle{plain}{%  \fancyhead{} % get rid of headers  \renewcommand{\headrulewidth}{0pt} % and the line.}%%定义空白页面\makeatletter\def\cleardoublepage{\clearpage\if@twoside \ifodd\c@page\else  \hbox{}  \vspace*{\fill}  \begin{center}   {\sffamily\large}   \end{center}   \vspace{\fill}   \thispagestyle{empty}   \newpage   \if@twocolumn\hbox{}\newpage\fi\fi\fi}\makeatother\makeatletter\def\cleardedicatepage{\clearpage  \hbox{}  \vspace*{\fill}  \begin{center}   {\sffamily\Large 献给我的女儿刘楚溪}   \end{center}   \vspace{\fill}   \thispagestyle{empty}   \newpage   \if@twocolumn\hbox{}\newpage\fi}\makeatother%% 有时会出现\headheight too small的warning\setlength{\headheight}{15pt}
+%%%% fancyhdr设置页眉页脚
+%% 页眉页脚宏包
+\usepackage{fancyhdr}
+
+%% 页眉页脚风格
+\pagestyle{fancy}
+
+%%这两行代码是修改\leftmark和\rightmark的经典模式
+\renewcommand{\chaptermark}[1]{\markboth{{\hei {第\thechapter{}章}}\hspace{1em} #1}{}}
+\renewcommand{\sectionmark}[1]{\markright{\thesection{} #1}}
+
+%% 清空当前页眉页脚的默认设置
+\fancyhf{}
+
+%\fancyhead[L]{\scriptsize \fangsong \ascii{ZTE}中兴}
+%\fancyhead[R]{\scriptsize \fangsong 内部公开}
+
+%\fancyhead[CE]{\scriptsize \fangsong \leftmark}
+%\fancyhead[CO]{\scriptsize \fangsong \rightmark}
+
+%\fancyfoot[RO, LE]{\scriptsize \thepage}
+%\fancyfoot[C]{\scriptsize \fangsong 本文中的所有信息均为中兴通讯股份有限公司内部信息，不得向外传播}
+
+\renewcommand{\headrulewidth}{0.4pt}
+\renewcommand{\footrulewidth}{0.4pt}
+
+%第{\couriernew\thechapter{}}章
+%%下面开始修改页眉和页脚
+\fancyhead[RE]{\fangsong \leftmark}
+\fancyhead[LO]{\fangsong \rightmark}
+\fancyhead[RO, LE]{\small \thepage}
+\fancypagestyle{plain}{%
+  \fancyhead{} % get rid of headers
+  \renewcommand{\headrulewidth}{0pt} % and the line.
+}
+
+%%定义空白页面
+\makeatletter
+\def\cleardoublepage{\clearpage\if@twoside \ifodd\c@page\else
+  \hbox{}
+  \vspace*{\fill}
+  \begin{center}
+   {\sffamily\large}
+   \end{center}
+   \vspace{\fill}
+   \thispagestyle{empty}
+   \newpage
+   \if@twocolumn\hbox{}\newpage\fi\fi\fi}
+\makeatother
+
+\makeatletter
+\def\cleardedicatepage{\clearpage
+  \hbox{}
+  \vspace*{\fill}
+  \begin{center}
+   {\sffamily\Large 献给我的女儿刘楚溪}
+   \end{center}
+   \vspace{\fill}
+   \thispagestyle{empty}
+   \newpage
+   \if@twocolumn\hbox{}\newpage\fi}
+\makeatother
+
+%% 有时会出现\headheight too small的warning
+\setlength{\headheight}{15pt}


### PR DESCRIPTION
I have modify tex for some typo and change hspace bug in page.tex and some missing \end{content}.
Now, It can make in lastest Texlive in Debian 11. I tested and generate the new pdf. the index of catalogue is all right Now.
Please accept to PR, and thank you for your work to make this book 